### PR TITLE
JSignal fix on WSlider

### DIFF
--- a/src/Wt/WSlider.C
+++ b/src/Wt/WSlider.C
@@ -357,7 +357,7 @@ WSlider::WSlider(WContainerWidget *parent)
     maximum_(99),
     value_(0),
     valueChanged_(this),
-    sliderMoved_(this, "moved"),
+    sliderMoved_(this, "moved", true),
     paintedSlider_(0)
 { 
   resize(150, 50);
@@ -376,7 +376,7 @@ WSlider::WSlider(Orientation orientation, WContainerWidget *parent)
     maximum_(99),
     value_(0),
     valueChanged_(this),
-    sliderMoved_(this, "moved"),
+    sliderMoved_(this, "moved", true),
     paintedSlider_(0)
 { 
   if (orientation == Horizontal)


### PR DESCRIPTION
this solves the sliderMoved() signal not working using a JSlot or a std::string js function with that signal ("JSignal: connect(JSlot): signal does not collect JavaScript from slots").