### PR TITLE
Fix typo: unkown -> unknown

### DIFF
--- a/src/Wt/WRasterImage-gm.C
+++ b/src/Wt/WRasterImage-gm.C
@@ -612,7 +612,7 @@ void WRasterImage::drawImage(const WRectF& rect, const std::string& imgUri,
   if (cImage == 0) {
     LOG_ERROR("drawImage failed: "
 	      << (exception.reason ? exception.reason :
-		  "(unkown reason)") << ", "
+		  "(unknown reason)") << ", "
 	      << (exception.description ? exception.description :
 		  "(unknown description)") );
     return;

--- a/src/fcgi/WServer.C
+++ b/src/fcgi/WServer.C
@@ -71,7 +71,7 @@ struct WServer::Impl
     } catch (...) {
       LOG_ERROR_S(&server_,
 		  "fatal: dedicated session process for " << sessionId_ <<
-		  ": caught unkown, unhandled exception.");
+		  ": caught unknown, unhandled exception.");
 
       throw;
     }


### PR DESCRIPTION
Fix a couple of typos in printed-out messages