### PR TITLE
Fix Typo for ieAlternative

### DIFF
--- a/src/web/skeleton/Wt.js
+++ b/src/web/skeleton/Wt.js
@@ -3280,7 +3280,7 @@ function enableInternalPaths(initialHash) {
 function ieAlternative(d)
 {
   if (d.ieAlternativeExecuted) return '0';
-  self.emit(d.parentNode, 'IeAltnernative');
+  self.emit(d.parentNode, 'IeAlternative');
   d.style.width = '';
   d.ieAlternativeExecuted = true;
   return '0';


### PR DESCRIPTION
I have not tested this under IE7, but this seems to be a typo.