### PR TITLE
Wt::WRun throws on unknown command line parameters

### DIFF
--- a/src/http/Configuration.C
+++ b/src/http/Configuration.C
@@ -219,8 +219,8 @@ void Configuration::setOptions(int argc, char **argv,
     po::variables_map vm;
 
     if (argc)
-      po::store(po::parse_command_line(argc, argv, all_options), vm);
-
+      po::store(po::command_line_parser(argc, argv).options(all_options).allow_unregistered().run(), vm);
+      
     if (!configurationFile.empty()) {
       std::ifstream cfgFile(configurationFile.c_str(),
 	std::ios::in | std::ios::binary);


### PR DESCRIPTION
Wt::WRun throws if unknown command line parameters are present. Since Wt::WRun() is mostly a helper function, silent-ignore behavior seems reasonable. According to http://www.boost.org/doc/libs/1_56_0/doc/html/program_options/howto.html#idp344642720 "To allow unregistered options on the command line, you need to use the basic_command_line_parser class for parsing (not parse_command_line) and call the allow_unregistered method of that class".