### PR TITLE
WtDbo: Use SQLITE_TRANSIENT storage specifier for Sqlite blob binding

### DIFF
--- a/src/Wt/Dbo/backend/Sqlite3.C
+++ b/src/Wt/Dbo/backend/Sqlite3.C
@@ -199,7 +199,7 @@ public:
       err = sqlite3_bind_blob(st_, column + 1, "", 0, SQLITE_TRANSIENT);
     else 
       err = sqlite3_bind_blob(st_, column + 1, &(*(value.begin())),
-			      static_cast<int>(value.size()), SQLITE_STATIC);
+			      static_cast<int>(value.size()), SQLITE_TRANSIENT);
 
     handleErr(err);
   }


### PR DESCRIPTION
When writing a specialization of ```sql_value_traits::bind``` where data is generated and stored in a local variable (i.e an encrypted field) I noticed that the persisted data in the db would often be corrupted.

In the sqlite backend implementation, ```SQLITE_STATIC``` was used as the storage specifier, which assumes that the bound data will remain allocated until the statement is finalized. However finalization occurs after the scope of the ```sql_value_traits::bind``` method.

I understand not wanting to create a temporary copy of blob data (which could be quite large) when binding, but this implicit requirement to handle allocation beyond the scope of ```sql_value_traits::bind``` is a nasty gotcha?

Thanks for taking a look!