### PR TITLE
Honour CMAKE_PREFIX_PATH, the cmake standard way to specify a prefix …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,7 +234,13 @@ ELSE(WIN32)
     SET(CONFIGDIR "/etc/wt" CACHE STRING "Path for the configuration files")
   ENDIF( NOT DEFINED CONFIGDIR )
 
-  SET(USERLIB_PREFIX_DEFAULT "/usr")
+  # If the user specifies the standard CMAKE_PREFIX_PATH to find packages,
+  # honour it.
+  IF(CMAKE_PREFIX_PATH)
+    SET(USERLIB_PREFIX_DEFAULT ${CMAKE_PREFIX_PATH})
+  ELSE()
+    SET(USERLIB_PREFIX_DEFAULT "/usr")
+  ENDIF()
 
 ENDIF(WIN32)
 

--- a/cmake/WtFindSsl.txt
+++ b/cmake/WtFindSsl.txt
@@ -10,7 +10,9 @@
 # with /MDd, and release with /MD. Apparently that is what CMake uses for
 # these modes; it is currently unclear to me if cmake ever uses /MT variants.
 
-# default OSX SSL library is not OK, does not work with asio
+# Mac OS X: The system OpenSSL is deprecated since 10.7 (replaced by Common
+# Crypto). As such, it is rarely updated and is a security risk. You should
+# install a recent OpenSSL using either macports or brew.
 IF(APPLE)
   FIND_PATH(SSL_INCLUDE_DIRS
       openssl/ssl.h
@@ -18,7 +20,6 @@ IF(APPLE)
       ${SSL_PREFIX}/include/
       /usr/include/
       /usr/local/include/
-      c:/openssl/include/
     NO_DEFAULT_PATH
   )
 ELSE(APPLE)


### PR DESCRIPTION
…path to find packages.

This works on any OS, but especially on MacOSX it allows the user to avoid picking up the stale system OpenSSL, by invoking: cmake -D CMAKE_PREFIX_PATH=/opt/local.

Similar results can be already achieved with USERLIB_PREFIX. The difference is that USERLIB_PREFIX is a wt-specific way, while CMAKE_PREFIX_PATH is the standard cmake way to do the same. Actually I wonder why USERLIB_PREFIX exists at all :-)

Forgot to mention that without this patch, the cmake configuration steps fails because cmake is confused: it has found both OpenSSL below /opt/local and the system one:

    cmake -DCMAKE_PREFIX_PATH=/opt/local ..

    [..]
    -- Configuring done
    CMake Warning at src/CMakeLists.txt:442 (ADD_LIBRARY):
      Cannot generate a safe linker search path for target wt because files in
      some directories may conflict with libraries in implicit directories:

        link library [libssl.dylib] in /usr/lib may be hidden by files in:
          /opt/local/lib

      Some of these libraries may not be found correctly.
    [..]
